### PR TITLE
Use `change_tick` instead `read_change_tick`

### DIFF
--- a/crates/bevy_reactor_overlays/src/overlay.rs
+++ b/crates/bevy_reactor_overlays/src/overlay.rs
@@ -240,7 +240,7 @@ where
         }
 
         // Build the overlay mesh the first time.
-        let mut tracking = TrackingScope::new(world.read_change_tick());
+        let mut tracking = TrackingScope::new(world.change_tick());
         self.react(view_entity, world, &mut tracking);
 
         // Start reactions

--- a/src/callback.rs
+++ b/src/callback.rs
@@ -75,7 +75,7 @@ impl<'w, P: Send + Sync + 'static> CallDeferred<'w, P> {
 #[allow(dead_code)] // For now
 /// System that runs callbacks from an event listener.
 pub fn run_deferred_callbacks<P: 'static + Send + Sync>(world: &mut World) {
-    let tick = world.read_change_tick();
+    let tick = world.change_tick();
     let mut events = world.get_resource_mut::<Events<DeferredCall<P>>>().unwrap();
     let events = events.drain().collect::<Vec<_>>();
     let mut tracking = TrackingScope::new(tick);

--- a/src/compositor.rs
+++ b/src/compositor.rs
@@ -147,7 +147,7 @@ impl View for Compositor {
 
         // Insert components from effects.
         if !self.effects.is_empty() {
-            let mut tracking = TrackingScope::new(world.read_change_tick());
+            let mut tracking = TrackingScope::new(world.change_tick());
             for effect in self.effects.iter_mut() {
                 effect.start(image_entity, world, &mut tracking);
             }

--- a/src/cond.rs
+++ b/src/cond.rs
@@ -77,7 +77,7 @@ impl<
 
     fn build(&mut self, view_entity: Entity, world: &mut World) {
         world.entity_mut(view_entity).insert(Name::new("Cond"));
-        let mut tracking = TrackingScope::new(world.read_change_tick());
+        let mut tracking = TrackingScope::new(world.change_tick());
         self.react(view_entity, world, &mut tracking);
         world.entity_mut(view_entity).insert(tracking);
         assert!(

--- a/src/cx.rs
+++ b/src/cx.rs
@@ -37,7 +37,7 @@ pub trait RunContextWrite: RunContextRead {
     /// * `props` - The props to pass to the callback.
     fn run_callback<P: 'static>(&mut self, callback: Callback<P>, props: P) {
         let world = self.world_mut();
-        let tick = world.read_change_tick();
+        let tick = world.change_tick();
         let mut tracking = TrackingScope::new(tick);
         let mut cx = Cx::new(props, world, &mut tracking);
         let mut callback_entity = cx.world.entity_mut(callback.id);
@@ -164,7 +164,7 @@ pub trait RunContextSetup<'p> {
     //     &mut self,
     //     compute: F,
     // ) -> Signal<R> {
-    //     let ticks = self.world_mut().read_change_tick();
+    //     let ticks = self.world_mut().change_tick();
     //     let derived = self
     //         .world_mut()
     //         .spawn((
@@ -187,7 +187,7 @@ pub trait RunContextSetup<'p> {
     /// * `effect` - The function that computes the output. This will be called with a single
     ///    parameter, which is a [`Cx`] object.
     fn create_effect<F: Send + Sync + 'static + FnMut(&mut Cx<()>)>(&mut self, effect: F) {
-        let ticks = self.world_mut().read_change_tick();
+        let ticks = self.world_mut().change_tick();
         let action = Arc::new(Mutex::new(effect));
         let mut scope = TrackingScope::new(ticks);
         action.lock().unwrap()(&mut Cx::new((), self.world_mut(), &mut scope));

--- a/src/effect_target.rs
+++ b/src/effect_target.rs
@@ -39,7 +39,7 @@ where
         parent_scope: &mut TrackingScope,
     ) {
         // Create a tracking scope for the reaction.
-        let mut scope = TrackingScope::new(world.read_change_tick());
+        let mut scope = TrackingScope::new(world.change_tick());
 
         // Unwrap the reaction and update the target entity, since this was not known at
         // the time the reaction was constucted.
@@ -128,7 +128,7 @@ impl<R: Reaction + Send + Sync + 'static> EntityEffect for RunReactionEffect<R> 
     // Start a reaction which updates the bundle.
     fn start(&mut self, target: Entity, world: &mut World, parent_scope: &mut TrackingScope) {
         // Create a tracking scope for the reaction.
-        let mut scope = TrackingScope::new(world.read_change_tick());
+        let mut scope = TrackingScope::new(world.change_tick());
 
         // Unwrap the reaction and update the target entity, since this was not known at
         // the time the reaction was constucted.
@@ -209,7 +209,7 @@ impl<B: Bundle, F: Sync + Send + FnMut(&mut Rcx) -> B> Reaction for ComputedBund
 //     // Insert the bundle on build, then update.
 //     fn init(&mut self, target: Entity, world: &mut World) {
 //         assert!(self.tracker.is_none());
-//         let mut scope = TrackingScope::new(world.read_change_tick());
+//         let mut scope = TrackingScope::new(world.change_tick());
 //         let b = (self.init)();
 //         let mut entt = world.entity_mut(target);
 //         entt.insert(b);

--- a/src/element.rs
+++ b/src/element.rs
@@ -135,7 +135,7 @@ impl<B: Bundle + Default> View for Element<B> {
 
         // Insert components from effects.
         if !self.effects.is_empty() {
-            let mut tracking = TrackingScope::new(world.read_change_tick());
+            let mut tracking = TrackingScope::new(world.change_tick());
             for effect in self.effects.iter_mut() {
                 effect.start(display, world, &mut tracking);
             }

--- a/src/for_each.rs
+++ b/src/for_each.rs
@@ -222,7 +222,7 @@ impl<
     }
 
     fn build(&mut self, view_entity: bevy::prelude::Entity, world: &mut World) {
-        let mut tracking = TrackingScope::new(world.read_change_tick());
+        let mut tracking = TrackingScope::new(world.change_tick());
         self.react(view_entity, world, &mut tracking);
         world.entity_mut(view_entity).insert(tracking);
         assert!(

--- a/src/for_index.rs
+++ b/src/for_index.rs
@@ -68,7 +68,7 @@ impl<
     }
 
     fn build(&mut self, view_entity: bevy::prelude::Entity, world: &mut World) {
-        let mut tracking = TrackingScope::new(world.read_change_tick());
+        let mut tracking = TrackingScope::new(world.change_tick());
         self.react(view_entity, world, &mut tracking);
         world.entity_mut(view_entity).insert(tracking);
         assert!(

--- a/src/hover.rs
+++ b/src/hover.rs
@@ -54,7 +54,7 @@ impl<'p, 'w, Props> CreateHoverSignal for Cx<'p, 'w, Props> {
     fn create_hover_signal(&mut self, target: Entity) -> Signal<bool> {
         let mutable = self.create_mutable::<bool>(false);
         let mut reaction = HoverReaction { target };
-        let mut tracking = TrackingScope::new(self.world_mut().read_change_tick());
+        let mut tracking = TrackingScope::new(self.world_mut().change_tick());
         reaction.react(mutable.id, self.world_mut(), &mut tracking);
         self.world_mut()
             .entity_mut(mutable.id)

--- a/src/mutable.rs
+++ b/src/mutable.rs
@@ -220,7 +220,7 @@ mod tests {
     #[test]
     fn test_mutable_copy() {
         let mut world = World::default();
-        let mut scope = TrackingScope::new(world.read_change_tick());
+        let mut scope = TrackingScope::new(world.change_tick());
         let mut cx = Cx::new(&(), &mut world, &mut scope);
 
         let mutable = cx.create_mutable::<i32>(0);
@@ -250,7 +250,7 @@ mod tests {
     #[test]
     fn test_mutable_clone() {
         let mut world = World::default();
-        let mut scope = TrackingScope::new(world.read_change_tick());
+        let mut scope = TrackingScope::new(world.change_tick());
         let mut cx = Cx::new(&(), &mut world, &mut scope);
 
         let mutable = cx.create_mutable("Hello".to_string());

--- a/src/presenter.rs
+++ b/src/presenter.rs
@@ -72,7 +72,7 @@ impl<F: 'static, P: PresenterFn<F>> View for Bind<F, P> {
     fn build(&mut self, view_entity: Entity, world: &mut World) {
         assert!(self.inner.is_none());
         assert!(self.props.is_some());
-        let mut tracking = TrackingScope::new(world.read_change_tick());
+        let mut tracking = TrackingScope::new(world.change_tick());
         let mut cx = Cx::new(self.props.take().unwrap(), world, &mut tracking);
         let mut view = self.presenter.call(&mut cx);
         self.props = Some(cx.props);

--- a/src/switch.rs
+++ b/src/switch.rs
@@ -104,7 +104,7 @@ impl View for Switch {
     }
 
     fn build(&mut self, view_entity: Entity, world: &mut World) {
-        let mut tracking = TrackingScope::new(world.read_change_tick());
+        let mut tracking = TrackingScope::new(world.change_tick());
         self.react(view_entity, world, &mut tracking);
         world.entity_mut(view_entity).insert(tracking);
         assert!(

--- a/src/text.rs
+++ b/src/text.rs
@@ -87,7 +87,7 @@ impl<F: FnMut(&Rcx) -> String> View for TextComputed<F> {
 
     fn build(&mut self, view_entity: Entity, world: &mut World) {
         assert!(self.node.is_none());
-        let mut tracking = TrackingScope::new(world.read_change_tick());
+        let mut tracking = TrackingScope::new(world.change_tick());
         let re = Rcx::new(world, &mut tracking);
         let text = (self.text)(&re);
         let node = Some(

--- a/src/view.rs
+++ b/src/view.rs
@@ -206,7 +206,7 @@ impl<W: ViewFactory> View for ViewFactoryState<W> {
 
     fn build(&mut self, view_entity: Entity, world: &mut World) {
         assert!(self.inner.is_none());
-        let mut tracking = TrackingScope::new(world.read_change_tick());
+        let mut tracking = TrackingScope::new(world.change_tick());
         let mut cx = Cx::new((), world, &mut tracking);
         let mut view = self.factory.create(&mut cx);
         let inner = world.spawn(tracking).set_parent(view_entity).id();


### PR DESCRIPTION
 We already have `&mut World` use `change_tick` will have slightly better performance since it does not require atomic operation. Bevy docs also recommend this.
 >   Reads the current change tick of this world.
    If you have exclusive (`&mut`) access to the world, consider using [`change_tick()`](Self::change_tick),
    which is more efficient since it does not require atomic synchronization.