### PR TITLE
migrate to Bevy 0.15 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ exclude = [
 ]
 
 [workspace.dependencies]
-bevy = { version = "0.15.0-dev", features = ["ghost_nodes"] }
+bevy = { version = "0.15.0", features = ["ghost_nodes"] }
 bevy_reactor_builder = { path = "crates/bevy_reactor_builder" }
 bevy_reactor_obsidian = { path = "crates/bevy_reactor_obsidian" }
 bevy_reactor_signals = { path = "crates/bevy_reactor_signals" }
@@ -43,6 +43,6 @@ bevy_reactor_inspect = { workspace = true }
 bevy-inspector-egui = "0.26.0"
 pulldown-cmark = "0.12.2"
 
-[patch.crates-io]
-bevy = { git = "https://github.com/bevyengine/bevy.git", version = "0.15.0-dev" }
-bevy_ecs = { git = "https://github.com/bevyengine/bevy.git", version = "0.15.0-dev" }
+# [patch.crates-io]
+# bevy = { git = "https://github.com/bevyengine/bevy.git", version = "0.15.0-dev" }
+# bevy_ecs = { git = "https://github.com/bevyengine/bevy.git", version = "0.15.0-dev" }

--- a/crates/bevy_mod_stylebuilder/src/builder_background.rs
+++ b/crates/bevy_mod_stylebuilder/src/builder_background.rs
@@ -1,7 +1,8 @@
 use bevy::{
     prelude::*,
-    render::texture::Image,
-    ui::{self, UiImage},
+    image::Image,
+    ui::{self},
+    ui::widget::ImageNode,
 };
 
 use super::style_builder::StyleBuilder;
@@ -44,22 +45,22 @@ impl<'a, 'w> StyleBuilderBackground for StyleBuilder<'a, 'w> {
             MaybeHandleOrPath::Path(p) => Some(self.load_asset::<Image>(p)),
             MaybeHandleOrPath::None => None,
         };
-        match (texture, self.target.get_mut::<UiImage>()) {
+        match (texture, self.target.get_mut::<ImageNode>()) {
             (Some(texture), Some(mut uii)) => {
-                uii.texture = texture;
+                uii.image = texture;
                 uii.flip_x = flip_x;
                 uii.flip_y = flip_y;
             }
             (Some(texture), None) => {
-                self.target.insert(UiImage {
-                    texture,
+                self.target.insert(ImageNode {
+                    image: texture,
                     flip_x,
                     flip_y,
                     ..default()
                 });
             }
             (None, Some(_)) => {
-                self.target.remove::<UiImage>();
+                self.target.remove::<ImageNode>();
             }
             _ => (),
         };
@@ -76,15 +77,15 @@ impl<'a, 'w> StyleBuilderBackground for StyleBuilder<'a, 'w> {
     }
 
     fn background_image_color(&mut self, color: impl ColorParam) -> &mut Self {
-        match (color.to_val(), self.target.get_mut::<UiImage>()) {
+        match (color.to_val(), self.target.get_mut::<ImageNode>()) {
             (Some(color), Some(mut uii)) => {
                 uii.color = color;
             }
             (Some(color), None) => {
-                self.target.insert(UiImage { color, ..default() });
+                self.target.insert(ImageNode { color, ..default() });
             }
             (None, Some(_)) => {
-                self.target.remove::<UiImage>();
+                self.target.remove::<ImageNode>();
             }
             _ => (),
         };

--- a/crates/bevy_reactor_obsidian/Cargo.toml
+++ b/crates/bevy_reactor_obsidian/Cargo.toml
@@ -9,3 +9,4 @@ bevy = { workspace = true }
 bevy_mod_stylebuilder = { workspace = true }
 bevy_reactor_signals = { workspace = true }
 bevy_reactor_builder = { workspace = true }
+accesskit = "0.17.1"

--- a/crates/bevy_reactor_obsidian/src/controls/button.rs
+++ b/crates/bevy_reactor_obsidian/src/controls/button.rs
@@ -11,11 +11,11 @@ use crate::{
     tab_navigation::{AutoFocus, TabIndex},
     typography,
 };
+
+use accesskit::{self, Role};
+
 use bevy::{
-    a11y::{
-        accesskit::{NodeBuilder, Role},
-        AccessibilityNode,
-    },
+    a11y::AccessibilityNode,
     color::Luminance,
     prelude::*,
     ui,
@@ -253,7 +253,7 @@ impl UiTemplate for Button {
                 TabIndex(self.tab_index),
                 ButtonPressed(false),
                 ButtonState { on_click },
-                AccessibilityNode::from(NodeBuilder::new(Role::Button)),
+                AccessibilityNode::from(accesskit::Node::new(Role::Button)),
             ))
             .insert_if(self.autofocus, || AutoFocus)
             .create_children(|builder| {

--- a/crates/bevy_reactor_obsidian/src/controls/checkbox.rs
+++ b/crates/bevy_reactor_obsidian/src/controls/checkbox.rs
@@ -1,10 +1,9 @@
 use std::sync::Arc;
 
+use accesskit::{self, Role};
+
 use bevy::{
-    a11y::{
-        accesskit::{NodeBuilder, Role},
-        AccessibilityNode,
-    },
+    a11y::AccessibilityNode,
     color::Luminance,
     prelude::*,
     ui,
@@ -163,7 +162,7 @@ impl UiTemplate for Checkbox {
                     checked,
                     on_change: self.on_change,
                 },
-                AccessibilityNode::from(NodeBuilder::new(Role::CheckBox)),
+                AccessibilityNode::from(accesskit::Node::new(Role::CheckBox)),
             ))
             .insert_if(self.disabled, || Disabled)
             .create_children(|builder| {

--- a/crates/bevy_reactor_obsidian/src/controls/disclosure_toggle.rs
+++ b/crates/bevy_reactor_obsidian/src/controls/disclosure_toggle.rs
@@ -7,11 +7,11 @@ use crate::{
     prelude::{CreateFocusSignal, TabIndex},
     size::Size,
 };
+
+use accesskit::{self, Role};
+
 use bevy::{
-    a11y::{
-        accesskit::{NodeBuilder, Role},
-        AccessibilityNode,
-    },
+    a11y::AccessibilityNode,
     prelude::*,
     ui,
     window::SystemCursorIcon,
@@ -139,7 +139,7 @@ impl UiTemplate for DisclosureToggle {
                     checked: self.expanded,
                 },
                 TabIndex(self.tab_index),
-                AccessibilityNode::from(NodeBuilder::new(Role::CheckBox)),
+                AccessibilityNode::from(accesskit::Node::new(Role::CheckBox)),
             ))
             .style_dyn(
                 move |rcx| focused.get(rcx),

--- a/crates/bevy_reactor_obsidian/src/controls/tool_palette.rs
+++ b/crates/bevy_reactor_obsidian/src/controls/tool_palette.rs
@@ -2,13 +2,11 @@ use std::sync::Arc;
 
 use crate::{prelude::RoundedCorners, size::Size};
 use bevy::{
-    a11y::{
-        accesskit::{NodeBuilder, Role},
-        AccessibilityNode,
-    },
+    a11y::AccessibilityNode,
     prelude::*,
     ui,
 };
+use accesskit::{self, Role};
 use bevy_mod_stylebuilder::*;
 use bevy_reactor_builder::{
     CreateChilden, EntityStyleBuilder, InvokeUiTemplate, UiBuilder, UiTemplate,
@@ -102,7 +100,7 @@ impl UiTemplate for ToolPalette {
                 self.style.clone(),
             ))
             .insert(ToolPaletteContext { size: self.size })
-            .insert(AccessibilityNode::from(NodeBuilder::new(Role::Group)))
+            .insert(AccessibilityNode::from(accesskit::Node::new(Role::Group)))
             .create_children(|builder| {
                 (self.children.as_ref())(builder);
             });

--- a/crates/bevy_reactor_signals/src/callback.rs
+++ b/crates/bevy_reactor_signals/src/callback.rs
@@ -37,7 +37,7 @@ pub trait AnyCallback: 'static {
 impl<P: 'static> AnyCallback for Callback<P> {
     fn remove(&self, world: &mut World) {
         // println!("Removing callback");
-        world.remove_system(self.id).unwrap();
+        world.unregister_system(self.id).unwrap();
     }
 }
 


### PR DESCRIPTION
Mostly small name changers since 0.15-dev. 

- Accesskit is no longer included with a11y. 
- world.remove_system -> world.unregister_system. [a8c610a52dd449fa4c287b4ffb9bfb83a213ebd6](https://github.com/bevyengine/bevy/commit/a8c610a52dd449fa4c287b4ffb9bfb83a213ebd6)
